### PR TITLE
Mudança nomes dos robôs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Para a versão em PT-BR 🇧🇷 desse documento, veja [aqui](./CHANGELOG.pt-br.md)
 
+## [3.0.0] - 2021-03-26
+
+### Changed
+
+- Robots names now follow the convention /[yellow|blue]_team/robot[0..2]. This change applies to robots model name and topics namespace
+
 ## [2.1.0] - 2021-03-22
 
 ### Added

--- a/CHANGELOG.pt-br.md
+++ b/CHANGELOG.pt-br.md
@@ -3,6 +3,12 @@
 O formato é baseado no [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 e esse projeto segue a convenção [versionamento semântico](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2021-03-26
+
+### Modificado
+
+- Nomes dos robôs agora seguem a convenção /[yellow|blue]_team/robot[0..2]. Essa mudança se aplica aos nomes dos modelos dos robôs e ao namespace dos tópicos
+
 ## [2.1.0] - 2021-03-22
 
 ### Adicionado

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Vector3  angular
 
 The ROS topics follow the naming convention:
 
-- **/robot[1..3]/vss_robot_diff_drive_controller/cmd_vel**
-- **/foe[1..3]/vss_robot_diff_drive_controller/cmd_vel**
+- **/yellow_team/robot[0..2]/vss_robot_diff_drive_controller/cmd_vel**
+- **/blue_team/robot[0..2]/vss_robot_diff_drive_controller/cmd_vel**
 
 The control of the robot is performed by the [diff_driver_controller](http://wiki.ros.org/diff_drive_controller) from the library [ros_control](http://wiki.ros.org/ros_control). The controller represents the behavior of the embedded system of the robot and will send torque commands to the motors in order to follow the received set point.
 
@@ -102,10 +102,10 @@ The simulation also accepts control directly over **angular velocity** commands 
 
 The commands are read from topics of type [std_msgs/Float64](http://docs.ros.org/noetic/api/std_msgs/html/msg/Float64.html), representing each motor's speed in **rad/s**
 
-- **/robot[1..3]/vss_robot_left_controller/command**
-- **/robot[1..3]/vss_robot_right_controller/command**
-- **/foe[1..3]/vss_robot_left_controller/command**
-- **/foe[1..3]/vss_robot_right_controller/command**
+- **/yellow_team/robot[0..2]/vss_robot_left_controller/command**
+- **/yellow_team/robot[0..2]/vss_robot_right_controller/command**
+- **/blue_team/robot[0..2]/vss_robot_left_controller/command**
+- **/blue_team/robot[0..2]/vss_robot_right_controller/command**
 
 In order to enable this control interface, one should send the parameter `twist_interface` as false in roslaunch [parameters](#-parameters)
 
@@ -135,8 +135,8 @@ string reference_frame      # set pose/twist relative to the frame of this entit
 
 The republished topics are
 
-- **/vision/robot[1...3]** - Team robots's topics
-- **/vision/foe[1...3]** - Adversary robots's topics
+- **/vision/yellow_team/robot[0..2]** - Yellow team robots's topics
+- **/vision/blue_team/robot[0..2]** - Blue team robots's topics
 - **/vision/ball** - Ball's topic
 
 All units are [SI](https://en.wikipedia.org/wiki/International_System_of_Units), distances are measured in meters, angles in radians, linear velocity in m/s and angular velocity in rad/s.

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -87,8 +87,8 @@ Vector3  angular
 
 Os tópicos ROS seguem a convenção de nomenclatura:
 
-- **/robot[1..3]/vss_robot_diff_drive_controller/cmd_vel**
-- **/foe[1..3]/vss_robot_diff_drive_controller/cmd_vel**
+- **/yellow_team/robot[0..2]/vss_robot_diff_drive_controller/cmd_vel**
+- **/blue_team/robot[0..2]/vss_robot_diff_drive_controller/cmd_vel**
 
 O controle do robô é feito pelo [diff_driver_controller](http://wiki.ros.org/diff_drive_controller). Os parâmetros de controle estão especificados no arquivo [./config/motor_diff_drive.yml](./config/motor_diff_drive.yml). O controlador representa o comportamento do sistema de controle embarcado no robô e envia comandos de torque para os motores de modo a seguir o set point recebido.
 
@@ -100,10 +100,10 @@ A simulação também aceita controle diretamente por meio de comandos de **velo
 
 Os comandos são lidos de tópicos do tipo [std_msgs/Float64](http://docs.ros.org/noetic/api/std_msgs/html/msg/Float64.html), representando a velocidade de cada motor em **rad/s**
 
-- **/robot[1..3]/vss_robot_left_controller/command**
-- **/robot[1..3]/vss_robot_right_controller/command**
-- **/foe[1..3]/vss_robot_left_controller/command**
-- **/foe[1..3]/vss_robot_right_controller/command**
+- **/yellow_team/robot[0..2]/vss_robot_left_controller/command**
+- **/yellow_team/robot[0..2]/vss_robot_right_controller/command**
+- **/blue_team/robot[0..2]/vss_robot_left_controller/command**
+- **/blue_team/robot[0..2]/vss_robot_right_controller/command**
 
 Para habilitar essa interface de controle, é necessário enviar o parâmetro `twist_interface` como false nos [parâmetros](#-parâmetros) do roslaunch
 
@@ -131,8 +131,8 @@ string reference_frame      # set pose/twist relative to the frame of this entit
 
 Os tópicos republicados são
 
-- **/vision/robot[1...3]** - Tópicos para os robôs do nosso time
-- **/vision/foe[1...3]** - Tópicos para os robôs adversários
+- **/vision/yellow_team/robot[0..2]** - Tópicos para os robôs do time amarelo
+- **/vision/blue_team/robot[0..2]** - Tópicos para os robôs do time azul
 - **/vision/ball** - Tópico para a bola
 
 Todas as unidades estão no SI, distâncias estão em metros, ângulos estão em radianos, velocidade linear está em m/s e velocidade angular está em rad/s

--- a/launch/simulation_match.launch
+++ b/launch/simulation_match.launch
@@ -31,13 +31,14 @@
   <!-- NOTE: The namespace prefix for the topic name is set in the <gazebo>
   inside the generic_vss_robot.gazebo file -->
 
-  <!-- Spawn frinds team -->
-  <!-- Spawn robot #1 -->
-  <group ns="robot1">
-    <param name="tf_prefix" value="robot1_tf" />
+  <!-- Spawn yellow team -->
+  <!-- Spawn yellow robot #1 -->
+  <group ns="yellow_team/robot_1">
+    <param name="tf_prefix" value="yellow_team/robot_1_tf" />
     <include file="$(find vss_simulation)/launch/spawn_robot.launch">
       <arg name="robot_number" value="1" />
-      <arg name="team_number" value="0" />
+      <arg name="is_yellow" value="true" />
+      <arg name="robot_name" value="yellow_team/robot_1" />
       <arg name="x" value="-0.2" />
       <arg name="y" value="0" />
       <arg name="model" value="$(arg model)" />
@@ -46,12 +47,13 @@
     </include>
   </group>
 
-  <!-- Spawn robot #2 -->
-  <group ns="robot2">
-    <param name="tf_prefix" value="robot2_tf" />
+  <!-- Spawn yellow robot #2 -->
+  <group ns="yellow_team/robot_2">
+    <param name="tf_prefix" value="yellow_team/robot_2_tf" />
     <include file="$(find vss_simulation)/launch/spawn_robot.launch">
       <arg name="robot_number" value="2" />
-      <arg name="team_number" value="0" />
+      <arg name="is_yellow" value="true" />
+      <arg name="robot_name" value="yellow_team/robot_2" />
       <arg name="x" value="-0.5" />
       <arg name="y" value="0.3" />
       <arg name="model" value="$(arg model)" />
@@ -60,12 +62,13 @@
     </include>
   </group>
 
-  <!-- Spawn robot #3 -->
-  <group ns="robot3">
-    <param name="tf_prefix" value="robot3_tf" />
+  <!-- Spawn yellow robot #3 -->
+  <group ns="yellow_team/robot_3">
+    <param name="tf_prefix" value="yellow_team/robot_3_tf" />
     <include file="$(find vss_simulation)/launch/spawn_robot.launch">
       <arg name="robot_number" value="3" />
-      <arg name="team_number" value="0" />
+      <arg name="is_yellow" value="true" />
+      <arg name="robot_name" value="yellow_team/robot_3" />
       <arg name="x" value="-0.5" />
       <arg name="y" value="-0.3" />
       <arg name="model" value="$(arg model)" />
@@ -73,16 +76,16 @@
       <arg name="config_file" value="$(arg config_file)"/>
     </include>
   </group>
-  <!-- /Spawn frinds team -->
+  <!-- /Spawn yellow team -->
 
-  <!-- Spawn foes team -->
-  <!-- Spawn foe #1 -->
-  <group ns="foe1">
-    <param name="tf_prefix" value="foe1_tf" />
+  <!-- Spawn blue team -->
+  <!-- Spawn blue robot #1 -->
+  <group ns="blue_team/robot_1">
+    <param name="tf_prefix" value="blue_team/robot_1_tf" />
     <include file="$(find vss_simulation)/launch/spawn_robot.launch">
       <arg name="robot_number" value="1" />
-      <arg name="team_number" value="1" />
-      <arg name="robot_name" value="foe1" />
+      <arg name="is_yellow" value="false" />
+      <arg name="robot_name" value="blue_team/robot_1" />
       <arg name="x" value="0.2" />
       <arg name="y" value="0" />
       <arg name="yaw" value="3.14159" />
@@ -92,13 +95,13 @@
     </include>
   </group>
 
-  <!-- Spawn foe #2 -->
-  <group ns="foe2">
-    <param name="tf_prefix" value="foe2_tf" />
+  <!-- Spawn blue robot #2 -->
+  <group ns="blue_team/robot_2">
+    <param name="tf_prefix" value="blue_team/robot_2_tf" />
     <include file="$(find vss_simulation)/launch/spawn_robot.launch">
       <arg name="robot_number" value="2" />
-      <arg name="team_number" value="1" />
-      <arg name="robot_name" value="foe2" />
+      <arg name="is_yellow" value="false" />
+      <arg name="robot_name" value="blue_team/robot_2" />
       <arg name="x" value="0.5" />
       <arg name="y" value="0.3" />
       <arg name="yaw" value="3.14159" />
@@ -108,13 +111,13 @@
     </include>
   </group>
 
-  <!-- Spawn foe #3 -->
-  <group ns="foe3">
-    <param name="tf_prefix" value="foe3_tf" />
+  <!-- Spawn blue robot #3 -->
+  <group ns="blue_team/robot_3">
+    <param name="tf_prefix" value="blue_team/robot_3_tf" />
     <include file="$(find vss_simulation)/launch/spawn_robot.launch">
       <arg name="robot_number" value="3" />
-      <arg name="team_number" value="1" />
-      <arg name="robot_name" value="foe3" />
+      <arg name="is_yellow" value="false" />
+      <arg name="robot_name" value="blue_team/robot_3" />
       <arg name="x" value="0.5" />
       <arg name="y" value="-0.3" />
       <arg name="yaw" value="3.14159" />
@@ -123,6 +126,6 @@
       <arg name="config_file" value="$(arg config_file)"/>
     </include>
   </group>
-  <!-- /Spawn foes team -->
+  <!-- /Spawn blue team -->
 
 </launch>

--- a/launch/simulation_match.launch
+++ b/launch/simulation_match.launch
@@ -32,6 +32,21 @@
   inside the generic_vss_robot.gazebo file -->
 
   <!-- Spawn yellow team -->
+  <!-- Spawn yellow robot #0 -->
+  <group ns="yellow_team/robot_0">
+    <param name="tf_prefix" value="yellow_team/robot_0_tf" />
+    <include file="$(find vss_simulation)/launch/spawn_robot.launch">
+      <arg name="robot_number" value="0" />
+      <arg name="is_yellow" value="true" />
+      <arg name="robot_name" value="yellow_team/robot_0" />
+      <arg name="x" value="-0.2" />
+      <arg name="y" value="0" />
+      <arg name="model" value="$(arg model)" />
+      <arg name="twist_interface" value="$(arg twist_interface)"/>
+      <arg name="config_file" value="$(arg config_file)"/>
+    </include>
+  </group>
+
   <!-- Spawn yellow robot #1 -->
   <group ns="yellow_team/robot_1">
     <param name="tf_prefix" value="yellow_team/robot_1_tf" />
@@ -39,8 +54,8 @@
       <arg name="robot_number" value="1" />
       <arg name="is_yellow" value="true" />
       <arg name="robot_name" value="yellow_team/robot_1" />
-      <arg name="x" value="-0.2" />
-      <arg name="y" value="0" />
+      <arg name="x" value="-0.5" />
+      <arg name="y" value="0.3" />
       <arg name="model" value="$(arg model)" />
       <arg name="twist_interface" value="$(arg twist_interface)"/>
       <arg name="config_file" value="$(arg config_file)"/>
@@ -55,21 +70,6 @@
       <arg name="is_yellow" value="true" />
       <arg name="robot_name" value="yellow_team/robot_2" />
       <arg name="x" value="-0.5" />
-      <arg name="y" value="0.3" />
-      <arg name="model" value="$(arg model)" />
-      <arg name="twist_interface" value="$(arg twist_interface)"/>
-      <arg name="config_file" value="$(arg config_file)"/>
-    </include>
-  </group>
-
-  <!-- Spawn yellow robot #3 -->
-  <group ns="yellow_team/robot_3">
-    <param name="tf_prefix" value="yellow_team/robot_3_tf" />
-    <include file="$(find vss_simulation)/launch/spawn_robot.launch">
-      <arg name="robot_number" value="3" />
-      <arg name="is_yellow" value="true" />
-      <arg name="robot_name" value="yellow_team/robot_3" />
-      <arg name="x" value="-0.5" />
       <arg name="y" value="-0.3" />
       <arg name="model" value="$(arg model)" />
       <arg name="twist_interface" value="$(arg twist_interface)"/>
@@ -79,6 +79,22 @@
   <!-- /Spawn yellow team -->
 
   <!-- Spawn blue team -->
+  <!-- Spawn blue robot #0 -->
+  <group ns="blue_team/robot_0">
+    <param name="tf_prefix" value="blue_team/robot_0_tf" />
+    <include file="$(find vss_simulation)/launch/spawn_robot.launch">
+      <arg name="robot_number" value="0" />
+      <arg name="is_yellow" value="false" />
+      <arg name="robot_name" value="blue_team/robot_0" />
+      <arg name="x" value="0.2" />
+      <arg name="y" value="0" />
+      <arg name="yaw" value="3.14159" />
+      <arg name="model" value="$(arg model)" />
+      <arg name="twist_interface" value="$(arg twist_interface)"/>
+      <arg name="config_file" value="$(arg config_file)"/>
+    </include>
+  </group>
+
   <!-- Spawn blue robot #1 -->
   <group ns="blue_team/robot_1">
     <param name="tf_prefix" value="blue_team/robot_1_tf" />
@@ -86,8 +102,8 @@
       <arg name="robot_number" value="1" />
       <arg name="is_yellow" value="false" />
       <arg name="robot_name" value="blue_team/robot_1" />
-      <arg name="x" value="0.2" />
-      <arg name="y" value="0" />
+      <arg name="x" value="0.5" />
+      <arg name="y" value="0.3" />
       <arg name="yaw" value="3.14159" />
       <arg name="model" value="$(arg model)" />
       <arg name="twist_interface" value="$(arg twist_interface)"/>
@@ -102,22 +118,6 @@
       <arg name="robot_number" value="2" />
       <arg name="is_yellow" value="false" />
       <arg name="robot_name" value="blue_team/robot_2" />
-      <arg name="x" value="0.5" />
-      <arg name="y" value="0.3" />
-      <arg name="yaw" value="3.14159" />
-      <arg name="model" value="$(arg model)" />
-      <arg name="twist_interface" value="$(arg twist_interface)"/>
-      <arg name="config_file" value="$(arg config_file)"/>
-    </include>
-  </group>
-
-  <!-- Spawn blue robot #3 -->
-  <group ns="blue_team/robot_3">
-    <param name="tf_prefix" value="blue_team/robot_3_tf" />
-    <include file="$(find vss_simulation)/launch/spawn_robot.launch">
-      <arg name="robot_number" value="3" />
-      <arg name="is_yellow" value="false" />
-      <arg name="robot_name" value="blue_team/robot_3" />
       <arg name="x" value="0.5" />
       <arg name="y" value="-0.3" />
       <arg name="yaw" value="3.14159" />

--- a/launch/simulation_robot.launch
+++ b/launch/simulation_robot.launch
@@ -27,7 +27,7 @@
     <arg name="recording" value="$(arg recording)"/>
   </include>
 
-  <group ns="robot1">
+  <group ns="yellow_team/robot_1">
     <include file="$(find vss_simulation)/launch/spawn_robot.launch">
       <arg name="model" value="$(arg model)" />
       <arg name="x" value="$(arg x)" />

--- a/launch/simulation_robot.launch
+++ b/launch/simulation_robot.launch
@@ -27,7 +27,7 @@
     <arg name="recording" value="$(arg recording)"/>
   </include>
 
-  <group ns="yellow_team/robot_1">
+  <group ns="yellow_team/robot_0">
     <include file="$(find vss_simulation)/launch/spawn_robot.launch">
       <arg name="model" value="$(arg model)" />
       <arg name="x" value="$(arg x)" />

--- a/launch/simulation_team.launch
+++ b/launch/simulation_team.launch
@@ -31,6 +31,21 @@
   <!-- NOTE: The namespace prefix for the topic name is set in the <gazebo>
     inside the generic_vss_robot.gazebo file -->
 
+  <!-- Spawn yellow robot #0 -->
+  <group ns="yellow_team/robot_0">
+    <param name="tf_prefix" value="yellow_team/robot_0_tf" />
+    <include file="$(find vss_simulation)/launch/spawn_robot.launch">
+      <arg name="robot_number" value="0" />
+      <arg name="is_yellow" value="true" />
+      <arg name="robot_name" value="yellow_team/robot_0" />
+      <arg name="x" value="-0.2" />
+      <arg name="y" value="0" />
+      <arg name="model" value="$(arg model)" />
+      <arg name="twist_interface" value="$(arg twist_interface)"/>
+      <arg name="config_file" value="$(arg config_file)"/>
+    </include>
+  </group>
+
   <!-- Spawn yellow robot #1 -->
   <group ns="yellow_team/robot_1">
     <param name="tf_prefix" value="yellow_team/robot_1_tf" />
@@ -38,8 +53,8 @@
       <arg name="robot_number" value="1" />
       <arg name="is_yellow" value="true" />
       <arg name="robot_name" value="yellow_team/robot_1" />
-      <arg name="x" value="-0.2" />
-      <arg name="y" value="0" />
+      <arg name="x" value="-0.5" />
+      <arg name="y" value="0.3" />
       <arg name="model" value="$(arg model)" />
       <arg name="twist_interface" value="$(arg twist_interface)"/>
       <arg name="config_file" value="$(arg config_file)"/>
@@ -53,21 +68,6 @@
       <arg name="robot_number" value="2" />
       <arg name="is_yellow" value="true" />
       <arg name="robot_name" value="yellow_team/robot_2" />
-      <arg name="x" value="-0.5" />
-      <arg name="y" value="0.3" />
-      <arg name="model" value="$(arg model)" />
-      <arg name="twist_interface" value="$(arg twist_interface)"/>
-      <arg name="config_file" value="$(arg config_file)"/>
-    </include>
-  </group>
-
-  <!-- Spawn yellow robot #3 -->
-  <group ns="yellow_team/robot_3">
-    <param name="tf_prefix" value="yellow_team/robot_3_tf" />
-    <include file="$(find vss_simulation)/launch/spawn_robot.launch">
-      <arg name="robot_number" value="3" />
-      <arg name="is_yellow" value="true" />
-      <arg name="robot_name" value="yellow_team/robot_3" />
       <arg name="x" value="-0.5" />
       <arg name="y" value="-0.3" />
       <arg name="model" value="$(arg model)" />

--- a/launch/simulation_team.launch
+++ b/launch/simulation_team.launch
@@ -31,11 +31,13 @@
   <!-- NOTE: The namespace prefix for the topic name is set in the <gazebo>
     inside the generic_vss_robot.gazebo file -->
 
-  <!-- Spawn robot #1 -->
-  <group ns="robot1">
-    <param name="tf_prefix" value="robot0_tf" />
+  <!-- Spawn yellow robot #1 -->
+  <group ns="yellow_team/robot_1">
+    <param name="tf_prefix" value="yellow_team/robot_1_tf" />
     <include file="$(find vss_simulation)/launch/spawn_robot.launch">
       <arg name="robot_number" value="1" />
+      <arg name="is_yellow" value="true" />
+      <arg name="robot_name" value="yellow_team/robot_1" />
       <arg name="x" value="-0.2" />
       <arg name="y" value="0" />
       <arg name="model" value="$(arg model)" />
@@ -44,11 +46,13 @@
     </include>
   </group>
 
-  <!-- Spawn robot #2 -->
-  <group ns="robot2">
-    <param name="tf_prefix" value="robot1_tf" />
+  <!-- Spawn yellow robot #2 -->
+  <group ns="yellow_team/robot_2">
+    <param name="tf_prefix" value="yellow_team/robot_2_tf" />
     <include file="$(find vss_simulation)/launch/spawn_robot.launch">
       <arg name="robot_number" value="2" />
+      <arg name="is_yellow" value="true" />
+      <arg name="robot_name" value="yellow_team/robot_2" />
       <arg name="x" value="-0.5" />
       <arg name="y" value="0.3" />
       <arg name="model" value="$(arg model)" />
@@ -57,11 +61,13 @@
     </include>
   </group>
 
-  <!-- Spawn robot #3 -->
-  <group ns="robot3">
-    <param name="tf_prefix" value="robot2_tf" />
+  <!-- Spawn yellow robot #3 -->
+  <group ns="yellow_team/robot_3">
+    <param name="tf_prefix" value="yellow_team/robot_3_tf" />
     <include file="$(find vss_simulation)/launch/spawn_robot.launch">
       <arg name="robot_number" value="3" />
+      <arg name="is_yellow" value="true" />
+      <arg name="robot_name" value="yellow_team/robot_3" />
       <arg name="x" value="-0.5" />
       <arg name="y" value="-0.3" />
       <arg name="model" value="$(arg model)" />

--- a/launch/spawn_robot.launch
+++ b/launch/spawn_robot.launch
@@ -5,8 +5,8 @@ http://wiki.ros.org/simulator_gazebo/Tutorials/Gazebo_ROS_API-->
 <launch>
 
   <arg name="robot_number" default="1" />
-  <arg name="team_number" default="0" />
-  <arg name="robot_name" default="$(eval 'robot'+str(team_number*3+robot_number))" />
+  <arg name="is_yellow" default="true" />
+  <arg name="robot_name" default="yellow_team/robot_1" />
   <arg name="x" default="0"/>
   <arg name="y" default="0"/>
   <arg name="z" default="0.03"/>
@@ -17,7 +17,7 @@ http://wiki.ros.org/simulator_gazebo/Tutorials/Gazebo_ROS_API-->
   <arg name="twist_interface" default="true"/>
   <arg name="config_file" default=""/>
 
-  <param name="robot_description" command="$(find xacro)/xacro $(arg model) robot_number:=$(arg robot_number) team_number:=$(arg team_number)" />
+  <param name="robot_description" command="$(find xacro)/xacro $(arg model) robot_number:=$(arg robot_number) is_yellow:=$(arg is_yellow)" />
 
   <!-- push robot_description to factory and spawn robot in gazebo -->
   <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" args="-x $(arg x) -y $(arg y) -z $(arg z)

--- a/launch/spawn_robot.launch
+++ b/launch/spawn_robot.launch
@@ -4,9 +4,9 @@ http://wiki.ros.org/simulator_gazebo/Tutorials/Gazebo_ROS_API-->
 
 <launch>
 
-  <arg name="robot_number" default="1" />
+  <arg name="robot_number" default="0" />
   <arg name="is_yellow" default="true" />
-  <arg name="robot_name" default="yellow_team/robot_1" />
+  <arg name="robot_name" default="yellow_team/robot_0" />
   <arg name="x" default="0"/>
   <arg name="y" default="0"/>
   <arg name="z" default="0.03"/>

--- a/scripts/vision_proxy.py
+++ b/scripts/vision_proxy.py
@@ -31,12 +31,13 @@ from gazebo_msgs.msg import ModelStates, ModelState
 
 # We take out every "vss_" prefix from our models
 MODELS_NAMES = ["vss_ball",
-                "robot1",
-                "robot2",
-                "robot3",
-                "foe1",
-                "foe2",
-                "foe3"]
+                "yellow_team/robot_0",
+                "yellow_team/robot_1",
+                "yellow_team/robot_2",
+                "blue_team/robot_0",
+                "blue_team/robot_1",
+                "blue_team/robot_2",
+                ]
 
 pubs = {}
 

--- a/urdf/generic_vss_robot.color
+++ b/urdf/generic_vss_robot.color
@@ -26,15 +26,15 @@
 
     <!-- Set robots colors -->
     <gazebo reference="chapeu_link">
-      <xacro:if value="${robot_number == 1}">
+      <xacro:if value="${robot_number == 0}">
         <material>TeamYellow/Robot1/Hat</material>
       </xacro:if>
 
-      <xacro:if value="${robot_number == 2}">
+      <xacro:if value="${robot_number == 1}">
         <material>TeamYellow/Robot2/Hat</material>
       </xacro:if>
 
-      <xacro:if value="${robot_number == 3}">
+      <xacro:if value="${robot_number == 2}">
         <material>TeamYellow/Robot3/Hat</material>
       </xacro:if>      <!-- /Set robots colors -->
     </gazebo>
@@ -65,15 +65,15 @@
 
     <!-- Set robots colors -->
     <gazebo reference="chapeu_link">
-      <xacro:if value="${robot_number == 1}">
+      <xacro:if value="${robot_number == 0}">
         <material>TeamBlue/Robot1/Hat</material>
       </xacro:if>
 
-      <xacro:if value="${robot_number == 2}">
+      <xacro:if value="${robot_number == 1}">
         <material>TeamBlue/Robot2/Hat</material>
       </xacro:if>
 
-      <xacro:if value="${robot_number == 3}">
+      <xacro:if value="${robot_number == 2}">
         <material>TeamBlue/Robot3/Hat</material>
       </xacro:if>      <!-- /Set robots colors -->
     </gazebo>

--- a/urdf/generic_vss_robot.color
+++ b/urdf/generic_vss_robot.color
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- Set team configuration -->
-  <xacro:if value="${team_number == 0}">
+  <xacro:if value="${is_yellow}">
 
     <gazebo reference="base_link">
       <material>Gazebo/Black</material>
@@ -41,7 +41,7 @@
   </xacro:if>  <!-- /Set team configuration -->
 
   <!-- Set team configuration -->
-  <xacro:if value="${team_number == 1}">
+  <xacro:unless value="${is_yellow}">
 
     <gazebo reference="base_link">
       <material>Gazebo/Black</material>
@@ -78,6 +78,6 @@
       </xacro:if>      <!-- /Set robots colors -->
     </gazebo>
 
-  </xacro:if>  <!-- /Set team configuration -->
+  </xacro:unless>  <!-- /Set team configuration -->
 
 </robot>

--- a/urdf/generic_vss_robot.gazebo
+++ b/urdf/generic_vss_robot.gazebo
@@ -38,12 +38,12 @@
   <!-- Load gazebo plugin to control the robot -->
   <gazebo>
     <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
-      <xacro:if value="${team_number == 0}">
-        <robotNamespace>/robot$(arg robot_number)</robotNamespace>
+      <xacro:if value="${is_yellow}">
+        <robotNamespace>/yellow_team/robot_$(arg robot_number)</robotNamespace>
       </xacro:if>
-      <xacro:if value="${team_number == 1}">
-        <robotNamespace>/foe$(arg robot_number)</robotNamespace>
-      </xacro:if>
+      <xacro:unless value="${is_yellow}">
+        <robotNamespace>/blue_team/robot_$(arg robot_number)</robotNamespace>
+      </xacro:unless>
     </plugin>
   </gazebo>
 </robot>

--- a/urdf/generic_vss_robot.xacro
+++ b/urdf/generic_vss_robot.xacro
@@ -4,10 +4,10 @@
   xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:arg name="robot_number" default="0" />
-  <xacro:arg name="team_number" default="0" />
+  <xacro:arg name="is_yellow" default="0" />
 
   <xacro:property name="robot_number" value="$(arg robot_number)" />
-  <xacro:property name="team_number" value="$(arg team_number)" />
+  <xacro:property name="is_yellow" value="$(arg is_yellow)" />
 
   <!-- Import all Gazebo-customization elements, except colors -->
   <xacro:include filename="$(find vss_simulation)/urdf/generic_vss_robot.gazebo" />


### PR DESCRIPTION
Salve salve garotada

Sem mais delongas, aqui está a mudança que eu estava devendo. Os nomes dos robôs foram trocados de modo a obedecer a regra

```
/[yellow|blue]_team/robot[0..2]
```

Em outras palavras, a numeração dos robôs passou a ser de 0 até 2, ao invés de 1 até 3 como originalmente. Outra mudança é a remoção de referências "friends" e "foes" para "time amarelo" e "time azul"

No mais, essas foram as mudanças. Tanto a documentação quanto o changelog foram atualizados de acordo

Fiquem bem e mantenham-se hidratados