### PR TITLE
🐛 Fix spawn syntax

### DIFF
--- a/launch/spawn_robot.launch
+++ b/launch/spawn_robot.launch
@@ -26,11 +26,11 @@ http://wiki.ros.org/simulator_gazebo/Tutorials/Gazebo_ROS_API-->
 
   <group if="$(arg twist_interface)">
     <!-- Load configs to control robot motors -->
-    <group if="$(eval config_file is '')">
+    <group if="$(eval config_file=='')">
       <rosparam command="load" file="$(find vss_simulation)/config/motor_diff_drive.yml" />
     </group>
 
-    <group unless="$(eval config_file is '')">
+    <group unless="$(eval config_file=='')">
       <rosparam command="load" file="config_file" />
     </group>
 
@@ -40,11 +40,11 @@ http://wiki.ros.org/simulator_gazebo/Tutorials/Gazebo_ROS_API-->
 
   <group unless="$(arg twist_interface)">
     <!-- Load configs to control robot motors -->
-    <group if="$(eval config_file is '')">
+    <group if="$(eval config_file=='')">
       <rosparam command="load" file="$(find vss_simulation)/config/motor_direct_drive.yml" />
     </group>
 
-    <group unless="$(eval config_file is '')">
+    <group unless="$(eval config_file=='')">
       <rosparam command="load" file="config_file" />
     </group>
 

--- a/launch/spawn_robot.launch
+++ b/launch/spawn_robot.launch
@@ -31,7 +31,7 @@ http://wiki.ros.org/simulator_gazebo/Tutorials/Gazebo_ROS_API-->
     </group>
 
     <group unless="$(eval config_file=='')">
-      <rosparam command="load" file="config_file" />
+      <rosparam command="load" file="$(find vss_simulation)/config/$(arg config_file)" />
     </group>
 
     <node name="vss_robot_controller" pkg="controller_manager" type="spawner" args="vss_robot_diff_drive_controller"/>
@@ -45,7 +45,7 @@ http://wiki.ros.org/simulator_gazebo/Tutorials/Gazebo_ROS_API-->
     </group>
 
     <group unless="$(eval config_file=='')">
-      <rosparam command="load" file="config_file" />
+      <rosparam command="load" file="$(find vss_simulation)/config/$(arg config_file)" />
     </group>
 
     <node name="vss_robot_controller" pkg="controller_manager" type="spawner" args="vss_robot_left_controller

--- a/launch/spawn_robot.launch
+++ b/launch/spawn_robot.launch
@@ -31,7 +31,7 @@ http://wiki.ros.org/simulator_gazebo/Tutorials/Gazebo_ROS_API-->
     </group>
 
     <group unless="$(eval config_file=='')">
-      <rosparam command="load" file="$(find vss_simulation)/config/$(arg config_file)" />
+      <rosparam command="load" file="$(arg config_file)" />
     </group>
 
     <node name="vss_robot_controller" pkg="controller_manager" type="spawner" args="vss_robot_diff_drive_controller"/>
@@ -45,7 +45,7 @@ http://wiki.ros.org/simulator_gazebo/Tutorials/Gazebo_ROS_API-->
     </group>
 
     <group unless="$(eval config_file=='')">
-      <rosparam command="load" file="$(find vss_simulation)/config/$(arg config_file)" />
+      <rosparam command="load" file="$(arg config_file)" />
     </group>
 
     <node name="vss_robot_controller" pkg="controller_manager" type="spawner" args="vss_robot_left_controller


### PR DESCRIPTION
Não sei como a gente não percebeu isso antes, mas eu tava rodando as coisas aqui no meu Ubuntu 20.04, ROS Noetic, e percebi o seguinte erro:

![image](https://user-images.githubusercontent.com/39196309/112764555-777b9980-8fdf-11eb-973b-cc0165993b1b.png)

Então fiz essa PR bem simples pra corrigir isso.